### PR TITLE
Fix: Remove Usage Of ?? To Support Legacy WebView

### DIFF
--- a/p2pml/src/main/resources/p2pml/static/index.html
+++ b/p2pml/src/main/resources/p2pml/static/index.html
@@ -45,7 +45,9 @@
           if (this.core) {
             this.destroyP2PEngine();
           }
-          this.core = new Core(this.coreConfig ?? {});
+
+          const cfg = this.coreConfig != null ? this.coreConfig : {};
+          this.core = new Core(cfg);
 
           this.core.addEventListener(
             "onChunkDownloaded",


### PR DESCRIPTION
**Background information**
Older Android WebViews and legacy browsers do not support the [ES2020 nullish coalescing operator](https://caniuse.com/mdn-javascript_operators_nullish_coalescing) (??). When the application executed code:
`this.core = new Core(this.coreConfig ?? {});`
these environments threw the following error:
`SyntaxError: Unexpected token ?`
This caused initialization failures in the P2P engine and prevented the application from loading on devices using outdated or non-updating WebView implementations.

**What Was Changed**
The nullish coalescing operator was replaced with an ES5-compatible check:

```javascript
const cfg = this.coreConfig != null ? this.coreConfig : {};
this.core = new Core(cfg);
```

This replicates the behavior of ?? (falling back only when the value is null or undefined) while avoiding syntax errors in older runtimes.